### PR TITLE
Add a pointer symbolization plugin (#1661)

### DIFF
--- a/angr/engines/successors.py
+++ b/angr/engines/successors.py
@@ -5,7 +5,7 @@ from archinfo.arch_soot import ArchSoot
 import logging
 l = logging.getLogger(name=__name__)
 
-class SimSuccessors(object):
+class SimSuccessors:
     """
     This class serves as a categorization of all the kinds of result states that can come from a
     SimEngine run.
@@ -208,7 +208,10 @@ class SimSuccessors(object):
 
             state._inspect('call', BP_AFTER)
         else:
-            while state.solver.is_true(state.regs._sp > state.callstack.top.stack_ptr):
+            while True:
+                cur_sp = state.solver.max(state.regs._sp) if state.has_plugin('symbolizer') else state.regs._sp
+                if not state.solver.is_true(cur_sp > state.callstack.top.stack_ptr):
+                    break
                 state._inspect('return', BP_BEFORE, function_address=state.callstack.top.func_addr)
                 state.callstack.pop()
                 state._inspect('return', BP_AFTER)

--- a/angr/sim_state.py
+++ b/angr/sim_state.py
@@ -9,7 +9,7 @@ l = logging.getLogger(name=__name__)
 import angr # type annotations; pylint:disable=unused-import
 import claripy
 import archinfo
-from archinfo.arch_soot import ArchSoot, SootAddressDescriptor
+from archinfo.arch_soot import SootAddressDescriptor
 
 from .misc.plugins import PluginHub, PluginPreset
 from .sim_state_options import SimStateOptions
@@ -61,6 +61,10 @@ class SimState(PluginHub):
         super(SimState, self).__init__()
         self.project = project
 
+        # Java & Java JNI
+        self._is_java_project = self.project and self.project.is_java_project
+        self._is_java_jni_project = self.project and self.project.is_java_jni_project
+
         # Arch
         if self._is_java_jni_project:
             self._arch = { "soot" : project.arch,
@@ -89,7 +93,7 @@ class SimState(PluginHub):
             options |= add_options
         if remove_options is not None:
             options -= remove_options
-        self._options = options
+        self.options = options
         self.mode = mode
         self.supports_inspect = False
 
@@ -228,6 +232,22 @@ class SimState(PluginHub):
 
         return "<SimState @ %s>" % ip_str
 
+    def __setattr__(self, key, value):
+        if key == 'options':
+            # set options
+            # this is done to both keep compatibility and make access to .options fast.
+            self._set_options(value)
+            return
+        super().__setattr__(key, value)
+
+    def _set_options(self, v):
+        if isinstance(v, (set, list)):
+            super().__setattr__("options", SimStateOptions(v))
+        elif isinstance(v, SimStateOptions):
+            super().__setattr__("options", v)
+        else:
+            raise SimStateError("Unsupported type '%s' in SimState.options.setter()." % type(v))
+
     #
     # Easier access to some properties
     #
@@ -297,19 +317,6 @@ class SimState(PluginHub):
         return self.solver.eval_one(self.regs._ip)
 
     @property
-    def options(self):
-        return self._options
-
-    @options.setter
-    def options(self, v):
-        if isinstance(v, (set, list)):
-            self._options = SimStateOptions(v)
-        elif isinstance(v, SimStateOptions):
-            self._options = v
-        else:
-            raise SimStateError("Unsupported type '%s' in SimState.options.setter()." % type(v))
-
-    @property
     def arch(self):
         if self._is_java_jni_project:
             return self._arch['soot'] if self.ip_is_soot_addr else self._arch['vex']
@@ -373,21 +380,6 @@ class SimState(PluginHub):
     #
     # Java support
     #
-
-    @property
-    def _is_java_project(self):
-        """
-        Indicates if the project's main binary is a Java Archive.
-        """
-        return self.project and self.project.is_java_project
-
-    @property
-    def _is_java_jni_project(self):
-        """
-        Indicates if the project's main binary is a Java Archive, which
-        interacts during its execution with native libraries (via JNI).
-        """
-        return self.project and self.project.is_java_jni_project
 
     @property
     def javavm_memory(self):

--- a/angr/state_plugins/__init__.py
+++ b/angr/state_plugins/__init__.py
@@ -30,3 +30,4 @@ from .heap import *
 from .concrete import *
 from .jni_references import *
 from .javavm_classloader import *
+from .symbolizer import *

--- a/angr/state_plugins/concrete.py
+++ b/angr/state_plugins/concrete.py
@@ -116,7 +116,7 @@ class Concrete(SimStatePlugin):
 
         # Synchronize the imported functions addresses (.got, IAT) in the
         # concrete process with ones used in the SimProcedures dictionary
-        if self.state.project._should_use_sim_procedures and not self.state.project.loader.main_object.pic:
+        if self.state.project.use_sim_procedures and not self.state.project.loader.main_object.pic:
             self._sync_simproc()
         else:
             l.debug("SimProc not restored, you are going to simulate also the code of external libraries!")

--- a/angr/state_plugins/inspect.py
+++ b/angr/state_plugins/inspect.py
@@ -28,6 +28,7 @@ event_types = {
     'vfg_handle_successor',
     'vfg_widen_state',
     'engine_process',
+    'memory_page_map',
 }
 
 inspect_attributes = {
@@ -123,6 +124,10 @@ inspect_attributes = {
     # engine_process
     'sim_engine',
     'sim_successors',
+
+    # memory mapping
+    'mapped_page',
+    'mapped_address',
     }
 
 NO_OVERRIDE = object()

--- a/angr/state_plugins/symbolizer.py
+++ b/angr/state_plugins/symbolizer.py
@@ -1,0 +1,266 @@
+import logging
+import claripy
+import struct
+
+l = logging.getLogger(name=__name__)
+l.setLevel('DEBUG')
+
+def _mem_write_cb(s): s.symbolizer._mem_write_callback()
+def _mem_read_cb(s): s.symbolizer._mem_read_callback()
+def _reg_write_cb(s): s.symbolizer._reg_write_callback()
+def _reg_read_cb(s): s.symbolizer._reg_read_callback()
+def _page_map_cb(s): s.symbolizer._page_map_callback()
+
+PAGE_SIZE = 0x1000
+
+from .plugin import SimStatePlugin
+class SimSymbolizer(SimStatePlugin): #pylint:disable=abstract-method
+    """
+    The symbolizer state plugin ensures that pointers that are stored in memory are symbolic.
+    This allows for the tracking of and reasoning over these pointers (for example, to reason
+    about memory disclosure).
+    """
+
+    def __init__(self):
+        SimStatePlugin.__init__(self)
+
+        self._symbolize_all = False
+        self.symbolization_target_pages = set()
+        self.ignore_target_pages = set()
+        self.symbolized_count = 0
+        self.page_symbols = { }
+        self._min_addr = None
+        self._max_addr = None
+
+        self._LE_FMT = None
+        self._BE_FMT = None
+        self._zero = None
+
+    def _page_map_callback(self):
+        if self._symbolize_all:
+            self.symbolization_target_pages.add(self.state.memory.mem._page_id(self.state.inspect.mapped_address))
+
+    def _mem_write_callback(self):
+        if not isinstance(self.state.inspect.mem_write_expr, int) and self.state.inspect.mem_write_expr.symbolic:
+            return
+        if not isinstance(self.state.inspect.mem_write_length, int) and self.state.inspect.mem_write_length.symbolic:
+            return
+
+        #length = self.state.solver.eval_one(self.state.inspect.mem_write_length)
+        #if length != self.state.arch.bytes:
+        #   return
+
+        write_expr = self.state.inspect.mem_write_expr
+        byte_expr = self.state.solver.eval_one(write_expr, cast_to=bytes).rjust(write_expr.length//8)
+        replacement_expr = self._resymbolize_data(byte_expr)
+        if replacement_expr is not None:
+            assert replacement_expr.length == write_expr.length
+            self.state.inspect.mem_write_expr = replacement_expr
+
+    def _reg_write_callback(self):
+        if not isinstance(self.state.inspect.reg_write_expr, int) and self.state.inspect.reg_write_expr.symbolic:
+            return
+        if not isinstance(self.state.inspect.reg_write_length, int) and self.state.inspect.reg_write_length.symbolic:
+            return
+        if self.state.inspect.reg_write_offset == self.state.arch.ip_offset:
+            return
+
+        length = self.state.solver.eval_one(self.state.inspect.reg_write_length)
+        if length != self.state.arch.bytes:
+            return
+
+        expr = self.state.solver.eval_one(self.state.inspect.reg_write_expr)
+        if self._should_symbolize(expr):
+            self.state.inspect.reg_write_expr = self._preconstrain(expr)
+
+    def init_state(self):
+        super().init_state()
+        assert self.state.memory.mem._page_size == PAGE_SIZE
+
+        self._LE_FMT = self.state.arch.struct_fmt(endness='Iend_LE')
+        self._BE_FMT = self.state.arch.struct_fmt(endness='Iend_BE')
+
+        # ignore CLE pages
+        for i in range(0, self.state.project.loader.kernel_object.map_size, PAGE_SIZE):
+            self.ignore_target_pages.add((self.state.project.loader.kernel_object.mapped_base+i)//PAGE_SIZE)
+        for i in range(0, self.state.project.loader.extern_object.map_size, PAGE_SIZE):
+            self.ignore_target_pages.add((self.state.project.loader.extern_object.mapped_base+i)//PAGE_SIZE)
+
+        self.state.inspect.make_breakpoint('memory_page_map', when=self.state.inspect.BP_BEFORE, action=_page_map_cb)
+        self.state.inspect.make_breakpoint('mem_write', when=self.state.inspect.BP_BEFORE, action=_mem_write_cb)
+        #self.state.inspect.make_breakpoint('mem_read', when=self.state.inspect.BP_BEFORE, action=_mem_read_cb)
+        #self.state.inspect.make_breakpoint('reg_write', when=self.state.inspect.BP_BEFORE, action=_reg_write_cb)
+        #self.state.inspect.make_breakpoint('reg_read', when=self.state.inspect.BP_BEFORE, action=_reg_read_cb)
+
+        self._zero = claripy.BVV(0, self.state.arch.bytes)
+
+    @staticmethod
+    def _page_id(x):
+        return x // PAGE_SIZE
+    @staticmethod
+    def _page_addr(p):
+        return p * PAGE_SIZE
+    @staticmethod
+    def _page_offset(p):
+        return p % PAGE_SIZE
+
+    def _update_ranges(self):
+        self._min_addr = self._page_addr(min(self.symbolization_target_pages))
+        self._max_addr = self._page_addr((max(self.symbolization_target_pages)+1))
+
+    def set_symbolization_for_all_pages(self):
+        """
+        Sets the symbolizer to symbolize pointers to all pages as they are written to memory..
+        """
+        self._symbolize_all = True
+        self.symbolization_target_pages.update(set(self.state.memory.mem._pages.keys()))
+        # handle bigger pages
+        for pg in self.state.memory.mem._pages.values():
+            if pg._page_size != PAGE_SIZE:
+                self.symbolization_target_pages.update(pg._page_size + i for i in range(0, pg._page_size, PAGE_SIZE))
+        self._update_ranges()
+
+    def set_symbolized_target_range(self, base, length):
+        """
+        All pointers to the target range will be symbolized as they are written to memory.
+
+        Due to optimizations, the _pages_ containing this range will be set as symbolization targets,
+        not just the range itself.
+        """
+        base_page = self._page_id(base)
+        pages = (length + self._page_offset(base) + PAGE_SIZE-1) // PAGE_SIZE
+        assert pages > 0
+        self.symbolization_target_pages.update(range(base_page, base_page+pages))
+        self._update_ranges()
+
+    def _preconstrain(self, value, name_prefix="address_"):
+        page_base = value & ~(PAGE_SIZE-1)
+        try:
+            symbol = self.page_symbols[page_base]
+        except KeyError:
+            symbol = claripy.BVS(name_prefix + hex(page_base), self.state.arch.bits)
+            self.page_symbols[page_base] = symbol
+            self.state.solver.add(symbol == page_base)
+        self.symbolized_count += 1
+        return symbol + (value - page_base)
+
+    def _should_symbolize(self, addr):
+        return self._page_id(addr) in self.symbolization_target_pages and not self._page_id(addr) in self.ignore_target_pages
+
+    def _resymbolize_int(self, be, le=0, base=0, offset=0, skip=()):
+        if base+offset in skip:
+            return None
+        elif self._min_addr <= be < self._max_addr and self._should_symbolize(be):
+            s = self._preconstrain(be)
+            l.debug("Replacing %#x (at %#x, endness BE) with %s!", be, base+offset, s)
+            return s
+        elif self._min_addr <= le < self._max_addr and self._should_symbolize(le):
+            s = self._preconstrain(le).reversed
+            l.debug("Replacing %#x (at %#x, endness LE) with %s!", le, base+offset, s)
+            return s
+        else:
+            return None
+
+    def _resymbolize_data(self, data, prefix=b"", base=0, skip=()):
+        ws = self.state.arch.bytes
+        suffix = data[len(data)-(len(data)%ws):]
+        data = data[:len(data)-(len(data)%ws)]
+
+        num_words = len(data) // ws
+        unpacked_le = struct.unpack(self._LE_FMT[0] + str(num_words) + self._LE_FMT[1], data)
+        unpacked_be = struct.unpack(self._BE_FMT[0] + str(num_words) + self._BE_FMT[1], data)
+
+        values_squashed = [ prefix ]
+        last_idx = 0
+        for i,(be,le) in enumerate(zip(unpacked_be, unpacked_le)):
+            #assert len(claripy.Concat(*values_squashed)) == i*8
+
+            s = self._resymbolize_int(be, le, base, i*ws, skip)
+            if s is None:
+                return None
+
+            if last_idx != i:
+                values_squashed.append(data[last_idx*ws:i*ws])
+            last_idx = i + 1
+            values_squashed.append(s)
+
+        if len(values_squashed) == 1:
+            return None
+
+        if last_idx != num_words:
+            values_squashed.append(data[last_idx*ws:])
+        values_squashed.append(suffix)
+
+        new_data = claripy.Concat(*values_squashed)
+        #assert len(new_data)/8 == len(data) + len(prefix)
+        #assert self.state.solver.eval_one(new_data) == self.state.solver.eval_one(claripy.BVV(data))
+        return new_data
+
+    def _resymbolize_region(self, storage, addr, length):
+        assert type(addr) is int
+        assert type(length) is int
+
+        self.state.scratch.push_priv(True)
+        memory_objects = storage.mem.load_objects(addr, length)
+        self.state.scratch.pop_priv()
+
+        for _,mo in memory_objects:
+            if not mo.is_bytes and mo.object.symbolic:
+                l.debug("Skipping symbolic memory object %s.", mo)
+                continue
+
+            aligned_base = mo.base - mo.base % (-self.state.arch.bytes)
+            remaining_len = mo.last_addr + 1 - aligned_base
+            if remaining_len < self.state.arch.bytes:
+                continue
+
+            data = mo.bytes_at(aligned_base, remaining_len, allow_concrete=True)
+            if not mo.is_bytes:
+                data = self.state.solver.eval_one(data, cast_to=bytes)
+            #assert self.state.solver.eval_one(storage.load(aligned_base, remaining_len, endness='Iend_BE'), cast_to=bytes).rjust(self.state.arch.bytes) == data
+
+            replacement_content = self._resymbolize_data(
+                data,
+                base=aligned_base,
+                prefix=mo.bytes_at(mo.base, mo.length - remaining_len) if aligned_base != mo.base else b"",
+                skip=() if storage is self.state.memory else (self.state.arch.ip_offset,)
+            )
+            if replacement_content is not None:
+                storage.mem.replace_memory_object(mo, replacement_content)
+
+    def resymbolize(self):
+        """
+        Re-symbolizes all pointers in memory. This can be called to symbolize any pointers to target regions
+        that were written (and not mangled beyond recognition) before symbolization was set.
+        """
+        #for i, p_id in enumerate(self.state.registers.mem._pages):
+        #   if i % 100 == 0:
+        #       l.info("%s/%s register pages symbolized", i, len(self.state.registers.mem._pages))
+        #   addr_start = self.state.registers.mem._page_addr(p_id)
+        #   length = self.state.registers.mem._page_size
+        #   self._resymbolize_region(self.state.registers, addr_start, length)
+        #self._resymbolize_region(self.state.registers, self.state.arch.sp_offset, 8)
+
+        for i, p_id in enumerate(self.state.memory.mem._pages):
+            if i % 100 == 0:
+                l.info("%s/%s memory pages symbolized", i, len(self.state.memory.mem._pages))
+            addr_start = self.state.memory.mem._page_addr(p_id)
+            length = self.state.memory.mem._page_size
+            self._resymbolize_region(self.state.memory, addr_start, length)
+
+    @SimStatePlugin.memo
+    def copy(self, memo): # pylint: disable=unused-argument
+        sc = SimSymbolizer()
+        sc._symbolize_all = self._symbolize_all
+        sc.symbolization_target_pages = set(self.symbolization_target_pages)
+        sc.ignore_target_pages = set(self.ignore_target_pages)
+        sc.symbolized_count = self.symbolized_count
+        sc._LE_FMT = self._LE_FMT
+        sc._BE_FMT = self._BE_FMT
+        sc._min_addr = self._min_addr
+        sc._max_addr = self._max_addr
+        sc.page_symbols = dict(sc.page_symbols)
+        return sc
+
+from ..sim_state import SimState
+SimState.register_default('symbolizer', SimSymbolizer)

--- a/angr/storage/paged_memory.py
+++ b/angr/storage/paged_memory.py
@@ -473,8 +473,7 @@ class SimPagedMemory:
                     if ret_on_segv:
                         break
                     raise SimSegfaultError(addr, 'read-miss')
-                else:
-                    continue
+                continue
 
             if self.allow_segv and not page.concrete_permissions & Page.PROT_READ:
                 #print "... SEGV"
@@ -490,10 +489,18 @@ class SimPagedMemory:
     #
 
     def _create_page(self, page_num, permissions=None):
-        return Page(
+        if self.state is not None:
+            self.state._inspect('memory_page_map', BP_BEFORE, mapped_address=page_num*self._page_size)
+
+        pg = Page(
             page_num*self._page_size, self._page_size,
             executable=self._executable_pages, permissions=permissions
         )
+
+        if self.state is not None:
+            self.state._inspect('memory_page_map', BP_AFTER, mapped_page=pg)
+            self.state._inspect_getattr('mapped_page', pg)
+        return pg
 
     def _initialize_page(self, n, new_page):
         if n in self._initialized:
@@ -749,8 +756,7 @@ class SimPagedMemory:
         except KeyError:
             if self.allow_segv:
                 raise SimSegfaultError(mo.base, 'write-miss')
-            else:
-                raise
+            raise
         if self.allow_segv and not page.concrete_permissions & Page.PROT_WRITE:
             raise SimSegfaultError(mo.base, 'non-writable')
 
@@ -788,7 +794,7 @@ class SimPagedMemory:
         :returns: the new memory object
         """
 
-        if old.object.size() != new_content.size():
+        if (old.object.size() if not old.is_bytes else len(old.object)*self.state.arch.byte_width) != new_content.size():
             raise SimMemoryError("memory objects can only be replaced by the same length content")
 
         new = SimMemoryObject(new_content, old.base, byte_width=self.byte_width)
@@ -1141,3 +1147,4 @@ class SimPagedMemory:
 
 
 from .. import sim_options as o
+from ..state_plugins.inspect import BP_BEFORE, BP_AFTER

--- a/tests/test_symbolization.py
+++ b/tests/test_symbolization.py
@@ -1,0 +1,26 @@
+import angr
+import os
+
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
+
+def test_fauxware_symbolization():
+	p = angr.Project(os.path.join(test_location, "x86_64", "fauxware"))
+	sm = p.factory.simulation_manager()
+
+	assert not sm.one_active.regs.rsp.symbolic
+
+	sm.one_active.symbolizer.set_symbolization_for_all_pages()
+	sm.one_active.symbolizer.resymbolize()
+
+	#assert sm.one_active.regs.rsp.symbolic
+	assert sm.one_active.symbolizer.symbolized_count
+
+	# make sure pointers get symbolized at runtime
+	n = sm.one_active.symbolizer.symbolized_count
+	sm.run()
+	assert not sm.errored
+	assert not sm.active
+	assert sm.one_deadended.symbolizer.symbolized_count > n
+
+if __name__ == '__main__':
+	test_fauxware_symbolization()


### PR DESCRIPTION
* add siminspect breakpoints for pages being mapped

* fix for replace_memory_object when bytes are stored

* optimize some dynamic properties

* IMPORTANT COMMIT: triggers constraint solver unsat bug when test_symbolization.py is run

* Working proof of concept, but symbolizing certain registers (i.e., rsp)
makes angr go haywire.

* be more careful with siminspect

* Speed optimizations.

* update logging

* make one variable per page, instead of per pointer

* Lint, including some lint-caught bugs!

* docstrings

* use a tuple for ip_offset skipping

* indirect import

* explicit comparison

* Less magic in __getattr__()s.

* Speed up .options and keep compatibility.

* parameterize page size, some other fixes

* re-inserting Lukas-hated change

* check page size assumption