### PR TITLE
Cleaning (#1751)

### DIFF
--- a/angr/analyses/forward_analysis/__init__.py
+++ b/angr/analyses/forward_analysis/__init__.py
@@ -233,15 +233,11 @@ class ForwardAnalysis:
             n = self._graph_visitor.next_node()
 
             if n is None:
-                # all done!
                 break
 
             job_state = self._get_input_state(n)
             if job_state is None:
                 job_state = self._initial_abstract_state(n)
-
-            if n is None:
-                break
 
             changed, output_state = self._run_on_node(n, job_state)
 

--- a/angr/analyses/reaching_definitions/engine_vex.py
+++ b/angr/analyses/reaching_definitions/engine_vex.py
@@ -445,16 +445,14 @@ class SimEngineRDVEX(
                 l.warning('Please implement the unknown function handler with your own logic.')
             return None
 
-        is_internal = False
         ext_func_name = None
-        if self.project.loader.main_object.contains_addr(ip_addr) is True:
+        if self.project.loader.main_object.contains_addr(ip_addr):
             ext_func_name = self.project.loader.find_plt_stub_name(ip_addr)
-            if ext_func_name is None:
-                is_internal = True
         else:
             symbol = self.project.loader.find_symbol(ip_addr)
             if symbol is not None:
                 ext_func_name = symbol.name
+        is_internal = ext_func_name is None
 
         executed_rda = False
         if ext_func_name is not None:

--- a/tests/test_function_manager.py
+++ b/tests/test_function_manager.py
@@ -1,86 +1,89 @@
 import nose
-import angr
-from angr.utils.constants import DEFAULT_STATEMENT
+import os
+
 from archinfo import ArchAMD64
 
-import logging
-l = logging.getLogger("angr.tests")
+import angr
+from angr.utils.constants import DEFAULT_STATEMENT
 
-import os
-test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
+TEST_LOCATION = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
 
 
-def test_amd64():
-    fauxware_amd64 = angr.Project(os.path.join(test_location, "x86_64", "fauxware"))
+class TestFunctionManager:
+    @classmethod
+    def setup_class(cls):
+        cls.project = angr.Project(os.path.join(TEST_LOCATION, "x86_64", "fauxware"))
 
-    EXPECTED_FUNCTIONS = { 0x4004e0, 0x400510, 0x400520, 0x400530, 0x400540, 0x400550, 0x400560, 0x400570,
-                           0x400580, 0x4005ac, 0x400640, 0x400664, 0x4006ed, 0x4006fd, 0x40071d, 0x4007e0,
-                           0x400880 }
-    EXPECTED_BLOCKS = { 0x40071D, 0x40073E, 0x400754, 0x40076A, 0x400774, 0x40078A, 0x4007A0, 0x4007B3, 0x4007C7,
-                        0x4007C9, 0x4007BD, 0x4007D3 }
-    EXPECTED_CALLSITES = { 0x40071D, 0x40073E, 0x400754, 0x40076A, 0x400774, 0x40078A, 0x4007A0, 0x4007BD, 0x4007C9 }
-    EXPECTED_CALLSITE_TARGETS = { 4195600, 4195632, 4195632, 4195600, 4195632, 4195632, 4195940, 4196077, 4196093 }
-    EXPECTED_CALLSITE_RETURNS = { 0x40073e, 0x400754, 0x40076a, 0x400774, 0x40078a, 0x4007a0, 0x4007b3, 0x4007c7,
-                                  None }
 
-    cfg = fauxware_amd64.analyses.CFGEmulated()  # pylint:disable=unused-variable
-    nose.tools.assert_equal(set([ k for k in fauxware_amd64.kb.functions.keys() if k < 0x500000 ]), EXPECTED_FUNCTIONS)
+    def test_amd64(self):
+        expected_functions = { 0x4004e0, 0x400510, 0x400520, 0x400530, 0x400540, 0x400550, 0x400560, 0x400570,
+                               0x400580, 0x4005ac, 0x400640, 0x400664, 0x4006ed, 0x4006fd, 0x40071d, 0x4007e0,
+                               0x400880 }
+        expected_blocks = { 0x40071D, 0x40073E, 0x400754, 0x40076A, 0x400774, 0x40078A, 0x4007A0, 0x4007B3, 0x4007C7,
+                            0x4007C9, 0x4007BD, 0x4007D3 }
+        expected_callsites = { 0x40071D, 0x40073E, 0x400754, 0x40076A, 0x400774, 0x40078A, 0x4007A0, 0x4007BD, 0x4007C9 }
+        expected_callsite_targets = { 4195600, 4195632, 4195632, 4195600, 4195632, 4195632, 4195940, 4196077, 4196093 }
+        expected_callsite_returns = { 0x40073e, 0x400754, 0x40076a, 0x400774, 0x40078a, 0x4007a0, 0x4007b3, 0x4007c7,
+                                      None }
 
-    main = fauxware_amd64.kb.functions.function(name='main')
-    nose.tools.assert_equal(main.startpoint.addr, 0x40071D)
-    nose.tools.assert_equal(set(main.block_addrs), EXPECTED_BLOCKS)
-    nose.tools.assert_equal([0x4007D3], [bl.addr for bl in main.endpoints])
-    nose.tools.assert_equal(set(main.get_call_sites()), EXPECTED_CALLSITES)
-    nose.tools.assert_equal(set(map(main.get_call_target, main.get_call_sites())), EXPECTED_CALLSITE_TARGETS)
-    nose.tools.assert_equal(set(map(main.get_call_return, main.get_call_sites())), EXPECTED_CALLSITE_RETURNS)
-    nose.tools.assert_true(main.has_return)
+        cfg = self.project.analyses.CFGEmulated()  # pylint:disable=unused-variable
+        nose.tools.assert_equal(
+            { k for k in self.project.kb.functions.keys() if k < 0x500000 },
+            expected_functions
+        )
 
-    rejected = fauxware_amd64.kb.functions.function(name='rejected')
-    nose.tools.assert_equal(rejected.returning, False)
+        main = self.project.kb.functions.function(name='main')
+        nose.tools.assert_equal(main.startpoint.addr, 0x40071D)
+        nose.tools.assert_equal(set(main.block_addrs), expected_blocks)
+        nose.tools.assert_equal([0x4007D3], [bl.addr for bl in main.endpoints])
+        nose.tools.assert_equal(set(main.get_call_sites()), expected_callsites)
+        nose.tools.assert_equal(
+            set(map(main.get_call_target, main.get_call_sites())),
+            expected_callsite_targets
+        )
+        nose.tools.assert_equal(
+            set(map(main.get_call_return, main.get_call_sites())),
+            expected_callsite_returns
+        )
+        nose.tools.assert_true(main.has_return)
 
-    # transition graph
-    main_g = main.transition_graph
-    main_g_edges_ = main_g.edges(data=True)
+        rejected = self.project.kb.functions.function(name='rejected')
+        nose.tools.assert_equal(rejected.returning, False)
 
-    # Convert nodes those edges from blocks to addresses
-    main_g_edges = [ ]
-    for src_node, dst_node, data in main_g_edges_:
-        main_g_edges.append((src_node.addr, dst_node.addr, data))
+        # transition graph
+        main_g = main.transition_graph
+        main_g_edges_ = main_g.edges(data=True)
 
-    nose.tools.assert_true((0x40071d, 0x400510, {'type': 'call', 'stmt_idx': DEFAULT_STATEMENT, 'ins_addr': 0x400739}) in
-                           main_g_edges
-                           )
-    nose.tools.assert_true((0x40071d, 0x40073e, {'type': 'fake_return', 'confirmed': True, 'outside': False}) in
-                           main_g_edges
-                           )
-    nose.tools.assert_true((0x40073e, 0x400530, {'type': 'call', 'stmt_idx': DEFAULT_STATEMENT, 'ins_addr': 0x40074f}) in main_g_edges)
-    nose.tools.assert_true((0x40073e, 0x400754, {'type': 'fake_return', 'confirmed': True, 'outside': False}) in main_g_edges)
+        # Convert nodes those edges from blocks to addresses
+        main_g_edges = []
+        for src_node, dst_node, data in main_g_edges_:
+            main_g_edges.append((src_node.addr, dst_node.addr, data))
 
-    # rejected() does not return
-    nose.tools.assert_true((0x4007c9, 0x4006fd, {'type': 'call', 'stmt_idx': DEFAULT_STATEMENT, 'ins_addr': 0x4007ce}) in main_g_edges)
-    nose.tools.assert_true((0x4007c9, 0x4007d3, {'type': 'fake_return', 'outside': False}) in main_g_edges)
+        edges = [
+            (0x40071d, 0x400510, {'type': 'call', 'stmt_idx': DEFAULT_STATEMENT, 'ins_addr': 0x400739}),
+            (0x40071d, 0x400510, {'type': 'call', 'stmt_idx': DEFAULT_STATEMENT, 'ins_addr': 0x400739}),
+            (0x40071d, 0x40073e, {'type': 'fake_return', 'confirmed': True, 'outside': False}),
+            (0x40073e, 0x400530, {'type': 'call', 'stmt_idx': DEFAULT_STATEMENT, 'ins_addr': 0x40074f}),
+            (0x40073e, 0x400754, {'type': 'fake_return', 'confirmed': True, 'outside': False}),
+            # rejected() does not return
+            (0x4007c9, 0x4006fd, {'type': 'call', 'stmt_idx': DEFAULT_STATEMENT, 'ins_addr': 0x4007ce}),
+            (0x4007c9, 0x4007d3, {'type': 'fake_return', 'outside': False}),
+        ]
+        for edge in edges:
+            nose.tools.assert_true(edge in main_g_edges)
 
-    # These tests fail for reasons of fastpath, probably
-    #nose.tools.assert_true(main.bp_on_stack)
-    #nose.tools.assert_equal(main.name, 'main')
-    #nose.tools.assert_true(main.retaddr_on_stack)
-    #nose.tools.assert_equal(0x50, main.sp_difference)
+        # These tests fail for reasons of fastpath, probably
+        #nose.tools.assert_true(main.bp_on_stack)
+        #nose.tools.assert_equal(main.name, 'main')
+        #nose.tools.assert_true(main.retaddr_on_stack)
+        #nose.tools.assert_equal(0x50, main.sp_difference)
 
-    #l.info(functions)
-    # TODO: Check the result returned
-    #func_man.dbg_draw()
-    #l.info("PNG files generated.")
+        # TODO: Check the result returned
+        #func_man.dbg_draw()
 
-def test_call_to():
-    project = angr.Project(os.path.join(test_location, 'x86_64', 'fauxware'))
-    project.arch = ArchAMD64()
+    def test_call_to(self):
+        self.project.arch = ArchAMD64()
 
-    project.kb.functions._add_call_to(0x400000, 0x400410, 0x400420, 0x400414)
-    nose.tools.assert_in(0x400000, project.kb.functions.keys())
-    nose.tools.assert_in(0x400420, project.kb.functions.keys())
-
-if __name__ == "__main__":
-    logging.getLogger('angr.analyses.cfg').setLevel(logging.DEBUG)
-
-    test_call_to()
-    test_amd64()
+        self.project.kb.functions._add_call_to(0x400000, 0x400410, 0x400420, 0x400414)
+        nose.tools.assert_in(0x400000, self.project.kb.functions.keys())
+        nose.tools.assert_in(0x400420, self.project.kb.functions.keys())

--- a/tests/test_reachingdefinitions.py
+++ b/tests/test_reachingdefinitions.py
@@ -249,14 +249,13 @@ class ReachingDefinitionAnalysisTest(TestCase):
 
 
     # @mock.patch.object(ReachingDefinitionAnalysis, '_analyze')
-    def test_reaching_definition_analysis_with_a_block_as_suject(self):
+    def test_reaching_definition_analysis_with_a_block_as_subject(self):
         binary_path = os.path.join(TESTS_LOCATION, 'x86_64', 'all')
         project = angr.Project(binary_path, load_options={'auto_load_libs': False})
         cfg = project.analyses.CFGFast()
 
         main_function = cfg.kb.functions['main']
-        block_node = main_function._addr_to_block_node[main_function.addr] # pylint: disable=W0212
-        main_block = Block(addr=0x42, byte_string=block_node.bytestr, project=project)
+        main_block = Block(addr=main_function.addr, project=project)
 
         reaching_definitions = project.analyses.ReachingDefinitions(subject=main_block)
 


### PR DESCRIPTION
* ForwardAnalysis: Remove redundant check

* ReachingDefinitions: Clarify logical affectations

* FunctionManager test: Set project only once

  * Using nose's `setup_class` method;
  * Hence breaking the call as a script (so remove the manual calls to
  the test functions).

* Tests: Simplify RDA test

* FunctionManager test: Add couple of updates

... to make linter happier.