### PR TITLE
Support entry point register initialization

### DIFF
--- a/angr/simos/linux.py
+++ b/angr/simos/linux.py
@@ -317,6 +317,8 @@ class SimLinux(SimUserland):
                 elif val == 'toc':
                     if self.project.loader.main_object.is_ppc64_abiv1:
                         state.registers.store(reg, self.project.loader.main_object.ppc64_initial_rtoc)
+                elif val == 'entry':
+                    state.registers.store(reg, state.registers.load('pc'))
                 elif val == 'thread_pointer':
                     state.registers.store(reg, self.project.loader.tls_object.user_thread_pointer)
                 else:


### PR DESCRIPTION
For PPC64 ABIv2, R12 should be initialized to the address of the first
function being invoked. To support this, this patch adds the ability to
initialize a register with the entry point address when creating an
entry state.