### PR TITLE
Fix deprecated CFG function usage (#1958)

### DIFF
--- a/angr/analyses/backward_slice.py
+++ b/angr/analyses/backward_slice.py
@@ -67,7 +67,7 @@ class BackwardSlice(Analysis):
         if targets is not None:
             for t in targets:
                 if isinstance(t, CodeLocation):
-                    node = self._cfg.get_any_node(t.block_addr)
+                    node = self._cfg.model.get_any_node(t.block_addr)
                     self._targets.append((node, t.stmt_idx))
                 elif type(t) is tuple:
                     self._targets.append(t)
@@ -406,7 +406,7 @@ class BackwardSlice(Analysis):
                     self.taint_graph.add_edge(p, tainted_cl)
 
             # Handle the control dependence
-            for n in self._cfg.get_all_nodes(tainted_cl.block_addr):
+            for n in self._cfg.model.get_all_nodes(tainted_cl.block_addr):
                 new_taints = self._handle_control_dependence(n)
 
                 l.debug("Returned %d taints for %s from control dependence graph", len(new_taints), n)
@@ -478,7 +478,7 @@ class BackwardSlice(Analysis):
             # Get the first two nodes
             a, b = simple_path[0], simple_path[1]
             # Get the exit statement ID from CFG
-            exit_stmt_id = self._cfg.get_exit_stmt_idx(a, b)
+            exit_stmt_id = self._cfg.model.get_exit_stmt_idx(a, b)
             if exit_stmt_id is None:
                 continue
 

--- a/angr/analyses/cdg.py
+++ b/angr/analyses/cdg.py
@@ -37,7 +37,7 @@ class CDG(Analysis):
                 self._cfg = self.project.analyses.CFGEmulated()
 
             # FIXME: We should not use get_any_irsb in such a real setting...
-            self._entry = self._cfg.get_any_node(self._start)
+            self._entry = self._cfg.model.get_any_node(self._start)
 
             self._construct()
 
@@ -164,7 +164,7 @@ class CDG(Analysis):
             successors = graph.graph.successors(node)
         else:
             # Real CFGNode!
-            successors = graph.get_successors(node)
+            successors = graph.model.get_successors(node)
 
         return successors
 

--- a/angr/analyses/ddg.py
+++ b/angr/analyses/ddg.py
@@ -793,7 +793,7 @@ class DDG(Analysis):
                     if (self._call_depth is None) or \
                             (self._call_depth is not None and 0 <= new_call_depth <= self._call_depth):
                         # Put all reachable successors back to our work-list again
-                        for successor in self._cfg.get_all_successors(node):
+                        for successor in self._cfg.model.get_all_successors(node):
                             nw = DDGJob(successor, new_call_depth)
                             self._worklist_append(nw, worklist, worklist_set)
 

--- a/angr/analyses/identifier/identify.py
+++ b/angr/analyses/identifier/identify.py
@@ -596,7 +596,7 @@ class Identifier(Analysis):
 
         all_addrs = set()
         for bl_addr in func.block_addrs:
-            all_addrs.update(set(self._cfg.get_any_node(bl_addr).instruction_addrs))
+            all_addrs.update(set(self._cfg.model.get_any_node(bl_addr).instruction_addrs))
 
         sp = main_state.solver.BVS("sym_sp", self.project.arch.bits, explicit_name=True)
         main_state.regs.sp = sp

--- a/angr/analyses/reassembler.py
+++ b/angr/analyses/reassembler.py
@@ -2155,7 +2155,7 @@ class Reassembler(Analysis):
 
         insn_addr = next(iter(refs.get_xrefs_by_dst(cgcpl_memory_data.addr))).ins_addr
         # get the basic block
-        cfg_node = self.cfg.get_any_node(insn_addr, anyaddr=True)
+        cfg_node = self.cfg.model.get_any_node(insn_addr, anyaddr=True)
         if not cfg_node:
             return False
 
@@ -2732,7 +2732,7 @@ class Reassembler(Analysis):
 
             # execute the single basic block and see how the value is used
             base_graph = networkx.DiGraph()
-            candidate_node = self.cfg.get_any_node(candidate.irsb_addr)  # type: angr.analyses.cfg_node.CFGNode
+            candidate_node = self.cfg.model.get_any_node(candidate.irsb_addr)  # type: angr.analyses.cfg_node.CFGNode
             if candidate_node is None:
                 continue
             base_graph.add_node(candidate_node)

--- a/angr/analyses/veritesting.py
+++ b/angr/analyses/veritesting.py
@@ -446,7 +446,7 @@ class Veritesting(Analysis):
         :returns bool: False if our CFG contains p.addr, True otherwise.
         """
 
-        n = self._cfg.get_any_node(s.addr, is_syscall=s.history.jumpkind.startswith('Ijk_Sys'))
+        n = self._cfg.model.get_any_node(s.addr, is_syscall=s.history.jumpkind.startswith('Ijk_Sys'))
         if n is None:
             return True
 
@@ -463,7 +463,7 @@ class Veritesting(Analysis):
         :param SimState state:          Current state to step on from
         :returns SimSuccessors:         The SimSuccessors object
         """
-        size_of_next_irsb = self._cfg.get_any_node(state.addr).size
+        size_of_next_irsb = self._cfg.model.get_any_node(state.addr).size
         return self.project.factory.successors(state, size=size_of_next_irsb)
 
     def is_overbound(self, state):

--- a/angr/analyses/vfg.py
+++ b/angr/analyses/vfg.py
@@ -1334,7 +1334,7 @@ class VFG(ForwardAnalysis, Analysis):   # pylint:disable=abstract-method
             jumpkind = state.history.jumpkind
 
         try:
-            node = self._cfg.get_any_node(addr)
+            node = self._cfg.model.get_any_node(addr)
             num_inst = None if node is None else len(node.instruction_addrs)
             sim_successors = self.project.factory.successors(state, jumpkind=jumpkind, num_inst=num_inst)
         except SimIRSBError as ex:

--- a/angr/exploration_techniques/explorer.py
+++ b/angr/exploration_techniques/explorer.py
@@ -55,13 +55,13 @@ class Explorer(ExplorationTechnique):
                 return
 
             for a in avoid:
-                if cfg.get_any_node(a) is None:
+                if cfg.model.get_any_node(a) is None:
                     l.warning("'Avoid' address %#x not present in CFG...", a)
 
             # not a queue but a stack... it's just a worklist!
             queue = []
             for f in static_find:
-                nodes = cfg.get_all_nodes(f)
+                nodes = cfg.model.get_all_nodes(f)
                 if len(nodes) == 0:
                     l.warning("'Find' address %#x not present in CFG...", f)
                 else:
@@ -125,7 +125,7 @@ class Explorer(ExplorationTechnique):
         avoidable = self.avoid(state)
 
         if not findable and not avoidable:
-            if self.cfg is not None and self.cfg.get_any_node(state.addr) is not None:
+            if self.cfg is not None and self.cfg.model.get_any_node(state.addr) is not None:
                 if state.addr not in self.ok_blocks:
                     return self.avoid_stash
             return None

--- a/angr/exploration_techniques/loop_seer.py
+++ b/angr/exploration_techniques/loop_seer.py
@@ -125,7 +125,7 @@ class LoopSeer(ExplorationTechnique):
         return simgr
 
     def successors(self, simgr, state, **kwargs):
-        node = self.cfg.get_any_node(state.addr)
+        node = self.cfg.model.get_any_node(state.addr)
         if node is not None:
             kwargs['num_inst'] = min(kwargs.get('num_inst', float('inf')), len(node.instruction_addrs))
         return simgr.successors(state, **kwargs)


### PR DESCRIPTION
* Updated calls to cfg.get_any_node(...)

* Updated calls to cfg.get_successors(...)

* Updated calls to cfg.get_all_successors(...)

* Updated calls to cfg.get_all_nodes(...)

* Updated calls to cfg.get_exit_stmt_idx(...)

* Reverted back to cfg.get_any_node(...) in blade.py