### PR TITLE
InitializationFinder analysis (#1961)

### DIFF
--- a/angr/analyses/__init__.py
+++ b/angr/analyses/__init__.py
@@ -32,4 +32,5 @@ from .decompiler import Decompiler
 from .soot_class_hierarchy import SootClassHierarchy
 from .propagator import PropagatorAnalysis
 from .xrefs import XRefsAnalysis
+from .init_finder import InitializationFinder
 from .complete_calling_conventions import CompleteCallingConventionsAnalysis

--- a/angr/analyses/cfg/cfg_fast.py
+++ b/angr/analyses/cfg/cfg_fast.py
@@ -1277,7 +1277,7 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
 
         # If they asked for it, give it to them.  All of it.
         if self._cross_references:
-            self._do_full_xrefs()
+            self.do_full_xrefs()
 
         r = True
         while r:
@@ -1287,10 +1287,17 @@ class CFGFast(ForwardAnalysis, CFGBase):    # pylint: disable=abstract-method
 
         self._finish_progress()
 
-    def _do_full_xrefs(self):
+    def do_full_xrefs(self, overlay_state=None):
+        """
+        Perform xref recovery on all functions.
+
+        :param SimState overlay:    An overlay state for loading constant data.
+        :return:                    None
+        """
+
         l.info("Building cross-references...")
         # Time to make our CPU hurt
-        state = self.project.factory.blank_state()
+        state = self.project.factory.blank_state() if overlay_state is None else overlay_state
         for f_addr in self.functions:
             f = None
             try:

--- a/angr/analyses/complete_calling_conventions.py
+++ b/angr/analyses/complete_calling_conventions.py
@@ -9,11 +9,11 @@ _l = logging.getLogger(name=__name__)
 
 class CompleteCallingConventionsAnalysis(Analysis):
 
-    def __init__(self, recover_variables=False, low_priority=False):
+    def __init__(self, recover_variables=False, low_priority=False, force=False):
 
         self._recover_variables = recover_variables
         self._low_priority = low_priority
-
+        self._force = force
         self._analyze()
 
     def _analyze(self):
@@ -32,7 +32,7 @@ class CompleteCallingConventionsAnalysis(Analysis):
         for idx, func_addr in enumerate(reversed(sorted_funcs)):
             func = self.kb.functions.get_by_addr(func_addr)
 
-            if func.calling_convention is None:
+            if func.calling_convention is None or self._force:
                 if func.alignment:
                     # skil all alignments
                     continue

--- a/angr/analyses/init_finder.py
+++ b/angr/analyses/init_finder.py
@@ -1,0 +1,221 @@
+
+from collections import defaultdict
+
+from cle.loader import MetaELF
+from cle.backends import Section, Segment
+import pyvex
+import claripy
+
+from ..engines.light import SimEngineLight, SimEngineLightVEXMixin
+from . import register_analysis
+from .analysis import Analysis
+from .forward_analysis import FunctionGraphVisitor, SingleNodeGraphVisitor, ForwardAnalysis
+from .propagator.vex_vars import VEXTmp
+
+
+class SimEngineInitFinderVEX(
+    SimEngineLightVEXMixin,
+    SimEngineLight,
+):
+    def __init__(self, project, replacements, overlay):
+        super().__init__()
+        self.project = project
+        self.replacements = replacements
+        self.overlay = overlay
+
+    #
+    # Utils
+    #
+
+    def _is_addr_uninitialized(self, addr):
+        # is it writing to a global, uninitialized region?
+
+        obj = self.project.loader.find_object_containing(addr)
+        if obj is not None:
+            if not obj.has_memory:
+                # Objects without memory are definitely uninitialized
+                return True
+            section = obj.find_section_containing(addr)  # type: Section
+            if section is not None:
+                return section.name in {'.bss', }
+
+            if isinstance(obj, MetaELF):
+                # for ELFs, if p_memsz >= p_filesz, the extra bytes are considered NOBITS
+                # https://docs.oracle.com/cd/E19120-01/open.solaris/819-0690/gjpww/index.html
+                segment = obj.find_segment_containing(addr)  # type: Segment
+                if segment is not None and segment.memsize > segment.filesize:
+                    return segment.vaddr + segment.filesize <= addr < segment.vaddr + segment.memsize
+        return False
+
+    #
+    # Statement handlers
+    #
+
+    def _handle_function(self, *args, **kwargs):
+        pass
+
+    def _handle_WrTmp(self, stmt):
+        # Don't do anything since constant propagation has already processed it
+        return
+
+    def _handle_Put(self, stmt):
+        # Don't do anything since constant propagation has already processed it
+        return
+
+    def _handle_Store(self, stmt):
+        blockloc = self._codeloc(block_only=True)
+
+        if type(stmt.addr) is pyvex.IRExpr.RdTmp:
+            addr_tmp = VEXTmp(stmt.addr.tmp)
+            if addr_tmp in self.replacements[blockloc]:
+                addr_v = self.replacements[blockloc][addr_tmp]
+                if isinstance(addr_v, int) and self._is_addr_uninitialized(addr_v):
+                    # do we know what it is writing?
+                    if isinstance(stmt.data, pyvex.IRExpr.RdTmp):
+                        data_v = self._expr(stmt.data)
+                        if isinstance(data_v, int):
+                            data_size = self.tyenv.sizeof(stmt.data.tmp)
+                            self.overlay.store(addr_v, claripy.BVV(data_v, data_size),
+                                               endness=self.project.arch.memory_endness
+                                               )
+
+    def _handle_StoreG(self, stmt):
+        blockloc = self._codeloc(block_only=True)
+        repl = self.replacements[blockloc]
+
+        if type(stmt.guard) is pyvex.IRExpr.RdTmp:
+            # check if guard is true
+            tmp = VEXTmp(stmt.guard.tmp)
+            if tmp not in repl or repl[tmp] is not True:
+                return
+        if type(stmt.addr) is pyvex.IRExpr.RdTmp:
+            tmp = VEXTmp(stmt.addr.tmp)
+            if tmp not in repl:
+                return
+            addr_v = repl[tmp]
+        else:
+            return
+
+        if not (isinstance(addr_v, int) and self._is_addr_uninitialized(addr_v)):
+            return
+
+        if type(stmt.data) is pyvex.IRExpr.RdTmp:
+            data_v = self._expr(stmt.data)
+        else:
+            return
+
+        if isinstance(data_v, int):
+            data_size = self.tyenv.sizeof(stmt.data.tmp)
+            self.overlay.store(addr_v, claripy.BVV(data_v, data_size),
+                               endness=self.project.arch.memory_endness
+                               )
+
+    #
+    # Expression handlers
+    #
+
+    def _handle_Get(self, expr):
+        return None
+
+    def _handle_Load(self, expr):
+        return None
+
+    def _handle_LoadG(self, stmt):
+        return None
+
+    def _handle_RdTmp(self, expr):
+        blockloc = self._codeloc(block_only=True)
+
+        tmp = VEXTmp(expr.tmp)
+        if tmp in self.replacements[blockloc]:
+            return self.replacements[blockloc][tmp]
+        return None
+
+
+class InitializationFinder(ForwardAnalysis, Analysis):  # pylint:disable=abstract-method
+    """
+    Finds possible initializations for global data sections and generate an overlay to be used in other analyses later
+    on.
+    """
+
+    def __init__(self, func=None, func_graph=None, block=None, max_iterations=1, replacements=None, overlay=None):
+        if func is not None:
+            if block is not None:
+                raise ValueError('You cannot specify both "func" and "block".')
+            # traversing a function
+            graph_visitor = FunctionGraphVisitor(func, func_graph)
+            if replacements is None:
+                prop = self.project.analyses.Propagator(func=func, func_graph=func_graph,
+                                                        base_state=self.project.factory.blank_state())
+                replacements = prop.replacements
+        elif block is not None:
+            # traversing a block
+            graph_visitor = SingleNodeGraphVisitor(block)
+            if replacements is None:
+                prop = self.project.analyses.Propagator(block=block,
+                                                        base_state=self.project.factory.blank_state())
+                replacements = prop.replacements
+        else:
+            raise ValueError('Unsupported analysis target.')
+
+        ForwardAnalysis.__init__(self, order_jobs=True, allow_merging=True, allow_widening=False,
+                                 graph_visitor=graph_visitor)
+
+        self._function = func
+        self._max_iterations = max_iterations
+        self._replacements = replacements
+
+        self._node_iterations = defaultdict(int)
+
+        self.overlay_state = None
+        if overlay is not None:
+            self.overlay = overlay
+        else:
+            self.overlay_state = self.project.factory.blank_state()
+            self.overlay = self.overlay_state.memory
+
+        self._engine_vex = SimEngineInitFinderVEX(self.project, replacements, self.overlay)
+        self._engine_ail = None
+
+        self._analyze()
+
+    #
+    # Main analysis routines
+    #
+
+    def _pre_analysis(self):
+        pass
+
+    def _pre_job_handling(self, job):
+        pass
+
+    def _initial_abstract_state(self, node):
+        return None
+
+    def _merge_states(self, node, *states):
+        return None
+
+    def _run_on_node(self, node, state):
+
+        block = self.project.factory.block(node.addr, node.size, opt_level=0)
+        block_key = node.addr
+        engine = self._engine_vex
+
+        engine.process(None, block=block, fail_fast=self._fail_fast)
+
+        self._node_iterations[block_key] += 1
+
+        if self._node_iterations[block_key] < self._max_iterations:
+            return True, None
+        else:
+            return False, None
+
+    def _intra_analysis(self):
+        pass
+
+    def _post_analysis(self):
+        pass
+
+
+register_analysis(InitializationFinder, "InitializationFinder")
+register_analysis(InitializationFinder, "InitFinder")

--- a/angr/analyses/variable_recovery/variable_recovery_fast.py
+++ b/angr/analyses/variable_recovery/variable_recovery_fast.py
@@ -368,8 +368,28 @@ class SimEngineVRVEX(
         addr = self._expr(stmt.addr)
         size = stmt.data.result_size(self.tyenv) // 8
         data = self._expr(stmt.data)
-
         self._store(addr, data, size, stmt=stmt)
+
+    def _handle_StoreG(self, stmt):
+        guard = self._expr(stmt.guard)
+        if guard is True:
+
+            addr = self._expr(stmt.addr)
+            size = stmt.data.result_size(self.tyenv) // 8
+            data = self._expr(stmt.data)
+            self._store(addr, data, size, stmt=stmt)
+
+    def _handle_LoadG(self, stmt):
+        guard = self._expr(stmt.guard)
+        if guard is True:
+            addr = self._expr(stmt.addr)
+            if addr is not None:
+                self.tmps[stmt.dst] = self._load(addr, self.tyenv.sizeof(stmt.dst) // 8)
+        elif guard is False:
+            data = self._expr(stmt.alt)
+            self.tmps[stmt.dst] = data
+        else:
+            self.tmps[stmt.dst] = None
 
     # Expression handlers
 

--- a/angr/analyses/xrefs.py
+++ b/angr/analyses/xrefs.py
@@ -57,7 +57,6 @@ class SimEngineXRefsVEX(
                 self.add_xref(XRefType.Write, self._codeloc(), addr)
 
     def _handle_LoadG(self, stmt):
-
         # What are we reading?
         blockloc = self._codeloc(block_only=True)
         if type(stmt.addr) is pyvex.IRExpr.RdTmp:
@@ -74,6 +73,10 @@ class SimEngineXRefsVEX(
         tmp = VEXTmp(data_tmp)
         if tmp in self.replacements[blockloc] and not isinstance(self.replacements[blockloc][tmp], Top):
             data = self.replacements[blockloc][tmp]
+            # Is this thing not an integer? If so, get out of here
+            # e.g., you can't find_object_containing on an SPOffset
+            if not isinstance(data, int):
+                return
             if data is not None and self.project.loader.find_object_containing(data) is not None:
                 # HACK: Avoid spamming Xrefs if the binary is loaded at 0
                 # e.g., firmware!
@@ -159,9 +162,9 @@ class XRefsAnalysis(ForwardAnalysis, Analysis):  # pylint:disable=abstract-metho
 
         self._analyze()
 
-        #
-        # Main analysis routines
-        #
+    #
+    # Main analysis routines
+    #
 
     def _pre_analysis(self):
         pass

--- a/angr/engines/light/engine.py
+++ b/angr/engines/light/engine.py
@@ -132,6 +132,9 @@ class SimEngineLightVEXMixin:
     def _handle_Store(self, stmt):
         raise NotImplementedError('Please implement the Store handler with your own logic.')
 
+    def _handle_StoreG(self, stmt):
+        raise NotImplementedError('Please implement the StoreG handler with your own logic.')
+
     #
     # Expression handlers
     #
@@ -157,6 +160,9 @@ class SimEngineLightVEXMixin:
 
     def _handle_Load(self, expr):
         raise NotImplementedError('Please implement the Load handler with your own logic.')
+
+    def _handle_LoadG(self, stmt):
+        raise NotImplementedError('Please implement the LoadG handler with your own logic.')
 
     def _handle_Exit(self, stmt):
         self._expr(stmt.guard)

--- a/tests/test_calling_convention_analysis.py
+++ b/tests/test_calling_convention_analysis.py
@@ -174,5 +174,6 @@ def run_all():
 if __name__ == "__main__":
     # logging.getLogger("angr.analyses.variable_recovery.variable_recovery_fast").setLevel(logging.DEBUG)
     logging.getLogger("angr.analyses.calling_convention").setLevel(logging.INFO)
-    run_all()
+    # run_all()
+    test_armel_fauxware()
     # test_dir_gcc_O0()

--- a/tests/test_init_finder.py
+++ b/tests/test_init_finder.py
@@ -1,0 +1,33 @@
+
+import os
+
+import nose.tools
+
+import angr
+
+
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
+
+
+def test_p2im_drone():
+    bin_path = os.path.join(test_location, "armel", "p2im_drone.elf")
+    proj = angr.Project(bin_path, auto_load_libs=False)
+    cfg = proj.analyses.CFG(data_references=True)
+
+    func = cfg.functions["Peripherals_Init"]
+    state = proj.factory.blank_state()
+    prop = proj.analyses.Propagator(func=func, base_state=state)
+
+    init_finder = proj.analyses.InitializationFinder(func=func, replacements=prop.replacements)
+    overlay = init_finder.overlay
+
+    # h12c1.Instance
+    nose.tools.assert_equal(state.solver.eval_one(overlay.load(0x20001500, 4, endness='Iend_LE')), 0x40005400)
+    # hi2c1.Init.AddressingMode
+    nose.tools.assert_equal(state.solver.eval_one(overlay.load(0x20001500+4+0xc, 4, endness='Iend_LE')), 0x4000)
+    # h12c1.Init.NoStretchMode
+    nose.tools.assert_equal(state.solver.eval_one(overlay.load(0x20001500+4+0x1c, 4, endness='Iend_LE')), 0)
+
+
+if __name__ == "__main__":
+    test_p2im_drone()

--- a/tests/test_xrefs.py
+++ b/tests/test_xrefs.py
@@ -55,5 +55,25 @@ def test_lwip_udpecho_bm_the_better_way():
     nose.tools.assert_equal(len(timenow_xrefs), 5)
 
 
+def test_p2im_drone_with_inits():
+    bin_path = os.path.join(test_location, "armel", "p2im_drone.elf")
+    proj = angr.Project(bin_path, auto_load_libs=False)
+    cfg = proj.analyses.CFG(data_references=True)
+
+    func = cfg.functions["Peripherals_Init"]
+    state = proj.factory.blank_state()
+    prop = proj.analyses.Propagator(func=func, base_state=state)
+
+    init_finder = proj.analyses.InitializationFinder(func=func, replacements=prop.replacements)
+    overlay_state = init_finder.overlay_state
+
+    cfg.do_full_xrefs(overlay_state=overlay_state)
+
+    h12c1_inst_xrefs = proj.kb.xrefs.get_xrefs_by_dst(0x20001500)
+    nose.tools.assert_equal(len(h12c1_inst_xrefs), 5)
+
+
 if __name__ == "__main__":
     test_lwip_udpecho_bm()
+    test_lwip_udpecho_bm_the_better_way()
+    test_p2im_drone_with_inits()


### PR DESCRIPTION
* Preliminary implementation of InitializersFinder.

* InitFinder: Support LoadG and StoreG.

* CFGFast: Support doing xrefs retroactively.

* InitFinder: Resilience against non-existent replacements.

* InitFinder: Use a base state when running propagator.

* Silence the spam from the init finder

* Add LoadG and StoreG support to VariableRecoveryFast

* Add option to force recomputation of CCA and VRF

* Don't make offset refs to SpOffsets or You're Gonna Have A Bad Time(tm)

* NamedRegions are definitely uninitialized

* Fix the use of tyenv.

* Lint the code.

* Rename initfinder.

Co-authored-by: Eric Gustafson <subwire@gmail.com>